### PR TITLE
Problem with uwsgi on dotcloud, so there is a new way of doing this, again

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -60,16 +60,12 @@ TEMPLATE_DIRS = (
 
 **PIP** ``pip install django-metasettings`` or **easy_install** ``easy_install django-metasettings``
 
-### Modify the project's __init__.py
-
-Before anything else can happen, Django MetaSettings needs to swap out the standard settings class with a custom subclass that works the magic.
-
-``` python
-import metasettings
-metasettings.init()
-```
-
 ### Modify the project's settings.py
+
+You can declare the METASETTINGS_* entries where you want in the ``settings.py`` file, but the line starting with ``metasettings.init`` should be at the end of the file.
+
+All settings after this line will overload those loaded with Django MetaSettings
+
 
 ``` python
 import metasettings
@@ -78,4 +74,5 @@ METASETTINGS_DIR = 'settings'
 METASETTINGS_PATTERNS = (
 	(r'hostname', ('base',),
 )
+metasettings.init(globals())
 ```

--- a/example/__init__.py
+++ b/example/__init__.py
@@ -1,3 +1,0 @@
-import metasettings
-
-metasettings.init()

--- a/example/settings.py
+++ b/example/settings.py
@@ -71,3 +71,5 @@ INSTALLED_APPS = (
 )
 
 MEDIA_ROOT = '/var/www/example.com/media'
+
+metasettings.init(globals())

--- a/metasettings/__init__.py
+++ b/metasettings/__init__.py
@@ -21,50 +21,33 @@ ENV = 'METASETTINGS_MATCHING_METHOD_ENVIRONMENTAL_VARIABLE'
 # Name of the environment variable containing the key for ENV matching
 ENV_NAME = 'METASETTINGS_KEY'
 
-def init():
-	"""
-	Initialize Django MetaSettings by replacing django.conf.settings with a MetaSettings object.
-	"""
-	django.conf.Settings = MetaSettings
 
+def init(_globals):
+	meta_method = _globals.get("METASETTINGS_METHOD", HOSTNAME) # Default to hostname matching
+	meta_dir = _globals.get("METASETTINGS_DIR", 'settings') # Default to the "settings" folder
+	meta_patterns = _globals.get("METASETTINGS_PATTERNS", (None, [])) # Default to something that just doesn't work
 
-class MetaSettings(django.conf.Settings):
-	def __init__(self, settings_module):
-		# Run the standard settings import
-		super(MetaSettings, self).__init__(settings_module)
+	match = {
+		HOSTNAME: lambda: socket.gethostname(),
+		FQDN: lambda: socket.getfqdn(),
+		PATH: lambda: None,
+		ENV: lambda: os.getenv(ENV_NAME),
+		None: lambda: None,
+	}.get(meta_method)()
 
-		meta_method = getattr(self, "METASETTINGS_METHOD", HOSTNAME) # Default to hostname matching
-		meta_dir = getattr(self, "METASETTINGS_DIR", self.SETTINGS_MODULE) # Default to the name of the settings module
-		meta_patterns = getattr(self, "METASETTINGS_PATTERNS", (None, [])) # Default to something that just doesn't work
+	# Match the environment
+	modules = [pattern[1] for pattern in meta_patterns if re.match(pattern[0], match)]
 
-		match = {
-			HOSTNAME: lambda: socket.gethostname(),
-			FQDN: lambda: socket.getfqdn(),
-			PATH: lambda: None,
-			ENV: lambda: os.getenv(ENV_NAME),
-			None: lambda: None,
-		}.get(meta_method)()
+	if len(modules) == 0:
+		raise Exception("No match for %s." % match)
 
-		# Match the environment
-		modules = [pattern[1] for pattern in meta_patterns if re.match(pattern[0], match)]
+	# There may be more than one match, default to the first
+	modules = modules[0]
 
-		if len(modules) == 0:
-			raise Exception("No match for %s." % match)
+	# Make sure the list of modules is iterable
+	if type(modules) not in (list, tuple):
+		modules = (modules,)
 
-		# There may be more than one match, default to the first
-		modules = modules[0]
-
-		# Make sure the list of modules is iterable
-		if type(modules) not in (list, tuple):
-			modules = (modules,)
-
-		# Initialize a settings dictionary to maintain scope between settings files
-		settings = dict((key, getattr(self, key)) for key in dir(self))
-
-		for module in modules:
-			execfile('%s/%s.py' % (meta_dir, module), globals(), settings)
-
-		# Move the settings into the local scope
-		for (setting, setting_value) in settings.items():
-			if setting == setting.upper():
-				setattr(self, setting, setting_value)
+	full_meta_dir = os.path.join(os.path.dirname(_globals['__file__']), meta_dir)
+	for module in modules:
+		execfile('%s/%s.py' % (full_meta_dir, module), _globals)


### PR DESCRIPTION
New way of overloading settings, with a simple call at the end of settings.py, without overloading django.conf.Settings (resolve a problem with dotcloud and uwsgi where this application was not working)

On the dotcloud hosting, they use nginx+uwsgi and django-Metasettings doesn't work. I don't know why, but it works fine in a `./manage.py shell` but not via the webserver.

So i rewrote your app to run this way : by adding a `mettasettings.init(global())` at the end of the `settings.py`, instead of the `__init__.py` of the project, we can just call the execfiles by passing the original `globals()` dict, and the work is magically done in this dict.

And there is no need to monkey-patch the `django.conf.Settings` class !

Tell me what you think about this way. 

PS : in github the diff seems horrible, but there is not so much changes !
